### PR TITLE
add default dummy LinkMask for DtcInterface::MonicaDigiClear()

### DIFF
--- a/otsdaq-mu2e-tracker/Ui/DtcInterface.hh
+++ b/otsdaq-mu2e-tracker/Ui/DtcInterface.hh
@@ -49,7 +49,7 @@ namespace trkdaq {
     int          EmulatesCfo() { return fEmulatesCfo; }
 
 
-    int          MonicaDigiClear(int LinkMask);
+    int          MonicaDigiClear(int LinkMask=0);
 
                                         // EWLength - in 25 ns ticks
     


### PR DESCRIPTION
Add a default `LinkMask` to `DtcInterface::MonicaDigiClear()` which does not update the internal member.